### PR TITLE
Remove std usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 
 [dependencies]
 serde_tuple_macros = { version = "1.0.0", path = "serde_tuple_macros" }
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1", features = ["derive"], default-features = false}
 
 [dev-dependencies]
 serde_json = "1.0.37"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
 //! println!("{}", &json);
 //! // # => ["Yes",22]
 //! ```
+#![no_std]
 
 pub use serde_tuple_macros::*;
 


### PR DESCRIPTION
These small changes help making this crate being able to be used in embedded devices by removing the std from being automatically added.

