### PR TITLE
fix: foreign attr clashes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde_tuple_macros = { version = "1.0.1", path = "serde_tuple_macros" }
 
 [dev-dependencies]
 serde_json = "1.0.37"
+derivative = "2"
 
 [lints]
 workspace = true

--- a/serde_tuple_macros/src/lib.rs
+++ b/serde_tuple_macros/src/lib.rs
@@ -33,7 +33,11 @@ pub fn derive_serialize_tuple(input: TokenStream) -> TokenStream {
 
     let ident = &item.ident;
     // Only keep serde attributes for the inner struct
-    let serde_attrs: Vec<_> = item.attrs.iter().filter(|attr| attr.path.is_ident("serde")).collect();
+    let serde_attrs: Vec<_> = item
+        .attrs
+        .iter()
+        .filter(|attr| attr.path.is_ident("serde"))
+        .collect();
     let serde_rename_line = parse_attrs(&item);
 
     let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
@@ -45,7 +49,11 @@ pub fn derive_serialize_tuple(input: TokenStream) -> TokenStream {
             let ident = field.ident.as_ref().unwrap();
             let ty = &field.ty;
             // Only keep serde attributes for the inner struct field
-            let serde_field_attrs: Vec<_> = field.attrs.iter().filter(|attr| attr.path.is_ident("serde")).collect();
+            let serde_field_attrs: Vec<_> = field
+                .attrs
+                .iter()
+                .filter(|attr| attr.path.is_ident("serde"))
+                .collect();
             (
                 quote!(#(#serde_field_attrs)* &'serde_tuple_inner #ty),
                 quote!(&self.#ident),
@@ -87,7 +95,11 @@ pub fn derive_deserialize_tuple(input: TokenStream) -> TokenStream {
 
     let ident = &item.ident;
     // Only keep serde attributes for the inner struct
-    let serde_attrs: Vec<_> = item.attrs.iter().filter(|attr| attr.path.is_ident("serde")).collect();
+    let serde_attrs: Vec<_> = item
+        .attrs
+        .iter()
+        .filter(|attr| attr.path.is_ident("serde"))
+        .collect();
     let serde_rename_line = parse_attrs(&item);
     let (_, ty_generics, where_clause) = item.generics.split_for_impl();
 
@@ -100,8 +112,15 @@ pub fn derive_deserialize_tuple(input: TokenStream) -> TokenStream {
             let ident = field.ident.as_ref().unwrap();
             let ty = &field.ty;
             // Only keep serde attributes for the inner struct field
-            let serde_field_attrs: Vec<_> = field.attrs.iter().filter(|attr| attr.path.is_ident("serde")).collect();
-            (quote!(#(#serde_field_attrs)* #ty), quote!(#ident: inner.#idx))
+            let serde_field_attrs: Vec<_> = field
+                .attrs
+                .iter()
+                .filter(|attr| attr.path.is_ident("serde"))
+                .collect();
+            (
+                quote!(#(#serde_field_attrs)* #ty),
+                quote!(#ident: inner.#idx),
+            )
         })
         .unzip();
 

--- a/tests/foreign_attrs.rs
+++ b/tests/foreign_attrs.rs
@@ -1,0 +1,29 @@
+// This tests that foreign attributes can be used with `serde_tuple`. Historically, deriving
+// `Serialize_tuple` or `Deserialize_tuple` would cause compilation errors if the struct had
+// foreign attributes, such as `#[derivative(Debug)]` from the `derivative` crate. This applied for
+// both the entire struct and individual fields.
+use derivative::Derivative;
+use serde_tuple::Serialize_tuple;
+
+#[derive(Derivative, Serialize_tuple)]
+#[derivative(Debug)]
+pub struct OwnStruct {
+    #[derivative(Debug = "ignore")]
+    value1: String,
+    value2: u64,
+}
+
+#[test]
+fn test_interop_attrs() {
+    let own_struct = OwnStruct {
+        value1: "Cthulhu".to_string(),
+        value2: 42,
+    };
+    // This will not print `value1` due to the `Debug = "ignore"` attribute
+    let debug_output = format!("{own_struct:?}");
+    assert_eq!(debug_output, "OwnStruct { value2: 42 }");
+
+    // serialize to json - should still have everything in tuple
+    let json_output = serde_json::to_string(&own_struct).unwrap();
+    assert_eq!(json_output, r#"["Cthulhu",42]"#);
+}


### PR DESCRIPTION
As described in the test file, deriving `Serialize_tuple` or `Deserialize_tuple` would break foreign, non-serde attributes. To my understanding, those derives should care exclusively about `serde` attributes.

This should make foreign derives work with the ones from this repository and reduce the resulting code slightly.